### PR TITLE
Preparation for OpenCL 2.0 C++ bindings

### DIFF
--- a/src/cl/binaries.cc
+++ b/src/cl/binaries.cc
@@ -4,12 +4,12 @@
 #include <utility>
 
 cl::Program createProgramFromBinaries(
-        cl::Context &context, std::vector<cl::Device> &devices, const std::string &name) 
+        cl::Context &context, std::vector<cl::Device> &devices, const std::string &name)
 {
   std::ifstream ifs(name, std::ios::in | std::ios::binary);
   std::string str((std::istreambuf_iterator<char>(ifs)), std::istreambuf_iterator<char>());
 
-  cl::Program::Binaries binaries(devices.size(), std::make_pair(str.c_str(), str.length()));
+  cl::Program::Binaries binaries{std::make_pair(str.c_str(), str.length())};
   return cl::Program(context, devices, binaries);
 } 
 

--- a/src/cl/binaries.hh
+++ b/src/cl/binaries.hh
@@ -1,7 +1,8 @@
 #pragma once
-#include <CL/cl.hpp>
 #include <vector>
 #include <string>
+
+#include "common.hh"
 
 extern cl::Program createProgramFromBinaries(
         cl::Context &context,

--- a/src/cl/cl.hh
+++ b/src/cl/cl.hh
@@ -1,15 +1,12 @@
 #pragma once
 
-#define __CL_ENABLE_EXCEPTIONS
-#include <CL/cl.hpp>
+#include "common.hh"
+
+#include "binaries.hh"
+#include "contexts.hh"
+#include "errors.hh"
 
 #undef CL_MEM_HOST_READ_ONLY  // 17.1 does not accept them, at least not in the emulator
 #define CL_MEM_HOST_READ_ONLY   0
 #undef CL_MEM_HOST_WRITE_ONLY
 #define CL_MEM_HOST_WRITE_ONLY  0
-
-#include "common.hh"
-#include "binaries.hh"
-#include "contexts.hh"
-#include "errors.hh"
-

--- a/src/cl/common.cc
+++ b/src/cl/common.cc
@@ -1,12 +1,11 @@
-#define __CL_ENABLE_EXCEPTIONS
-#include <CL/cl.hpp>
-
-#include "common.hh"
-#include "errors.hh"
 #include <iostream>
 #include <sstream>
 #include <fstream>
 #include <iomanip>
+
+#include "common.hh"
+#include "binaries.hh"
+#include "errors.hh"
 
 using namespace std;
 
@@ -83,13 +82,11 @@ cl::Program get_program(
 {
     os << ">>> Loading program from binary: " << filename << endl;
     try {
-        ifstream ifs(filename, ios::in | ios::binary);
-        string str((istreambuf_iterator<char>(ifs)), istreambuf_iterator<char>());
-        cl::Program::Binaries binaries(1, std::make_pair(str.c_str(), str.length()));
-        vector<cl::Device> devices;
+        std::vector<cl::Device> devices;
         devices.push_back(device);
+        auto result = createProgramFromBinaries(context, devices, filename);
         os << endl;
-        return cl::Program(context, devices, binaries);
+        return result;
     } catch (cl::Error& error) {
         cerr << "Loading binary failed: " << error.what() << endl
              << "Error code: " << error.err() << endl

--- a/src/cl/common.hh
+++ b/src/cl/common.hh
@@ -1,5 +1,7 @@
 #pragma once
+#define __CL_ENABLE_EXCEPTIONS
 #include <CL/cl.hpp>
+
 #include <vector>
 #include <string>
 #include <utility>
@@ -85,7 +87,7 @@ class Kernel
     void operator()(Args&&... args)
     {
         set_args(kernel, std::forward<Args>(args)...);
-        queue.enqueueTask(kernel, nullptr, &event);
+        queue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(1), cl::NullRange, nullptr, &event);
     }
 
     void finish();

--- a/src/cl/contexts.hh
+++ b/src/cl/contexts.hh
@@ -1,6 +1,5 @@
 #pragma once
-#include <CL/cl.hpp>
-#include <vector>
+#include "common.hh"
 
 extern void createContext(cl::Context &context, std::vector<cl::Device> &devices);
 

--- a/src/cl/errors.cc
+++ b/src/cl/errors.cc
@@ -1,4 +1,3 @@
-#include <CL/cl.hpp>
 #define FMT_HEADER_ONLY
 #include <fmt/format.h>
 

--- a/src/cl/errors.hh
+++ b/src/cl/errors.hh
@@ -1,6 +1,7 @@
 #pragma once
-#include <CL/cl.hpp>
 #include <string>
+
+#include "common.hh"
 
 extern std::string errorMessage(cl_int error);
 

--- a/src/ether/ether.cc
+++ b/src/ether/ether.cc
@@ -47,13 +47,12 @@ void ether(const argagg::parser_results& args)
     { throw std::runtime_error("failed to read packet file"); }
 
     cl::Event event;
-    cl::Kernel kernel(program, "sendUDP");
-    set_args(kernel, device_buf, chunkCount);
+    Kernel kernel(program, "sendUDP");
 
     queue.enqueueCopyBuffer(host_buf, device_buf, 0, 0, paddedPacketSize);
 
-    queue.enqueueTask(kernel, nullptr, &event);
-    queue.finish();
+    kernel(device_buf, chunkCount);
+    kernel.finish();
 
     queue.enqueueUnmapMemObject(host_buf, buffer);
 }

--- a/src/fft/fft_test.cc
+++ b/src/fft/fft_test.cc
@@ -45,7 +45,7 @@ void enqueue(
     cl::Kernel const &kernel,
     cl::Event &event)
 {
-    queue.enqueueTask(kernel, NULL, &event);
+    queue.enqueueNDRangeKernel(kernel, cl::NullRange, cl::NDRange(1), cl::NullRange, nullptr, &event);
 }
 
 template <typename T>


### PR DESCRIPTION
The 19.3 compiler switches to the OpenCL 2.0 C++ bindings, which deprecate a number of things. This PR fixes (most) of the code broken by this to be forward compatible with 2.0